### PR TITLE
Set cURL verbosity to false to avoid console output (#1016)

### DIFF
--- a/src/Http/Curl.php
+++ b/src/Http/Curl.php
@@ -66,6 +66,7 @@ class Curl implements HttpInterface
         curl_setopt($request, CURLOPT_HTTPHEADER, $headers);
         curl_setopt($request, CURLINFO_HEADER_OUT, true);
         curl_setopt($request, CURLOPT_SSL_VERIFYPEER, true);
+        curl_setopt($request, CURLOPT_VERBOSE, false);
 
         return $request;
     }


### PR DESCRIPTION
When used in an artisan command in L5.8 / PHP7.1.29, the curl_close command causes "* Closing connection 0" to be printed every time, for all Artisan commands. Setting verbosity to false will stop this output whilst still allowing exceptions to be caught.